### PR TITLE
EMP-15234 - Download sdk should not call `Delete` exposure Endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # CHANGELOG
 
- `2.2.30` Release - [2.2.30](#2230)
+* `2.2.40` Release - [2.2.40](#2240)
+* `2.2.30` Release - [2.2.30](#2230)
 * `2.2.20` Release - [2.2.20](#2220)
 * `2.2.10` Release - [2.2.10](#2210)
 * `2.2.00` Release - [2.2.00](#2200)
@@ -10,6 +11,10 @@
 * `0.78.0` Release - [0.78.0](#0780)
 * `0.77.x` Releases - [0.77.0](#0770)
 
+
+## 2.2.400
+#### Changes
+* `EMP-15234` Download sdk should not call `Delete` exposure Endpoint when deleting a downloaded asset 
 
 ## 2.2.300
 #### Changes

--- a/ExposureDownload.xcodeproj/project.pbxproj
+++ b/ExposureDownload.xcodeproj/project.pbxproj
@@ -586,7 +586,7 @@
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 2;
+				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = JCUPRVKEC5;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -596,7 +596,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 2.2.300;
+				MARKETING_VERSION = 2.2.400;
 				OTHER_LDFLAGS = (
 					"-weak_framework",
 					AVfoundation,
@@ -614,7 +614,7 @@
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 2;
+				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = JCUPRVKEC5;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -624,7 +624,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 2.2.300;
+				MARKETING_VERSION = 2.2.400;
 				OTHER_LDFLAGS = (
 					"-weak_framework",
 					AVfoundation,

--- a/ExposureDownload/Download/SessionManager+Exposure.swift
+++ b/ExposureDownload/Download/SessionManager+Exposure.swift
@@ -136,20 +136,6 @@ extension Download.SessionManager where T == ExposureDownloadTask {
     public func removeDownloadedAsset(assetId: String, sessionToken: SessionToken, environment: Environment) {
         guard let media = getDownloadedAsset(assetId: assetId) else { return }
         delete(media: media)
-        
-        DeleteDownload(assetId: assetId, environment:environment, sessionToken: sessionToken)
-        .request()
-        .validate()
-        .response { result in
-            
-            if result.error != nil {
-                print("🚨 Deletion request to the Backend was failed. Error from Exposure : \(result.error )" )
-            } else {
-                print("✅ Pass Deletion request to the Backend was success. Message from Exposure : \(result.value )" )
-            }
-        }
-        
-        
     }
     
     internal func save(assetId: String, accountId:String?, entitlement: PlayBackEntitlementV2?, url: URL?) {

--- a/ExposureDownload/Info.plist
+++ b/ExposureDownload/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>2</string>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSPrincipalClass</key>
 	<string></string>
 </dict>


### PR DESCRIPTION
Remove using `delete` endpoint when removing local media
Update change log & version